### PR TITLE
Soft destroy sale prices deleting prices and variants

### DIFF
--- a/app/models/spree/price_decorator.rb
+++ b/app/models/spree/price_decorator.rb
@@ -1,6 +1,6 @@
 Spree::Price.class_eval do
-  has_many :sale_prices
-  
+  has_many :sale_prices, dependent: :destroy
+
   def put_on_sale(value, params = {})
     new_sale(value, params).save
   end
@@ -15,7 +15,7 @@ Spree::Price.class_eval do
     }
     return sale_prices.new(sale_price_params)
   end
-  
+
   # TODO make update_sale method
 
   def active_sale
@@ -31,7 +31,7 @@ Spree::Price.class_eval do
   def sale_price
     active_sale.calculated_price if on_sale?
   end
-  
+
   def sale_price=(value)
     if on_sale?
       active_sale.update_attribute(:value, value)
@@ -53,11 +53,11 @@ Spree::Price.class_eval do
   def original_price
     self[:amount]
   end
-  
+
   def original_price=(value)
     self[:amount] = Spree::LocalizedNumber.parse(value)
   end
-  
+
   def price
     on_sale? ? sale_price : original_price
   end
@@ -69,7 +69,7 @@ Spree::Price.class_eval do
       self[:amount] = Spree::LocalizedNumber.parse(price)
     end
   end
-  
+
   def amount
     price
   end
@@ -89,7 +89,7 @@ Spree::Price.class_eval do
   def stop_sale
     active_sale.stop if active_sale.present?
   end
-  
+
   private
     def first_sale(scope)
       scope.order("created_at DESC").first

--- a/app/models/spree/sale_price.rb
+++ b/app/models/spree/sale_price.rb
@@ -1,5 +1,6 @@
 module Spree
   class SalePrice < ActiveRecord::Base
+    acts_as_paranoid
 
     belongs_to :price, class_name: "Spree::Price"
     delegate :currency, :currency=, to: :price
@@ -56,7 +57,7 @@ module Spree
 
     protected
       def touch_product
-        self.variant.product.touch
+        self.price.variant.product.touch unless deleted?
       end
 
   end

--- a/db/migrate/20170712151926_add_deleted_at_to_sale_price.rb
+++ b/db/migrate/20170712151926_add_deleted_at_to_sale_price.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToSalePrice < ActiveRecord::Migration
+  def change
+    add_column :spree_sale_prices, :deleted_at, :datetime
+    add_index :spree_sale_prices, :deleted_at
+  end
+end

--- a/spec/models/price_spec.rb
+++ b/spec/models/price_spec.rb
@@ -55,4 +55,12 @@ describe Spree::Price do
     end
   end
 
+  it 'destroys all sale prices when it is destroyed' do
+    price = create(:price)
+    price.put_on_sale 10
+
+    expect { price.destroy }
+      .to change { Spree::SalePrice.all.size }
+      .from(1).to(0)
+  end
 end

--- a/spec/models/variant_spec.rb
+++ b/spec/models/variant_spec.rb
@@ -148,6 +148,10 @@ describe Spree::Variant do
       end
     end
 
+    it 'destroys all sale prices when it is destroyed' do
+      expect { @variant.destroy }
+        .to change { Spree::SalePrice.all.size }
+        .from(3).to(0)
+    end
   end
-
 end


### PR DESCRIPTION
It is needed to do not leave zombie records when a variant is deleted.