### PR TITLE
Improve variant preload via SQL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,9 @@ gem "solidus", github: "solidusio/solidus", branch: branch
 gem 'pg', '~> 0.21'
 gem 'mysql2'
 
+# In order to allow testing on older version of Solidus that still
+# use the gem factory_girl we need to bundle an older version of
+# factory_bot:
+gem 'factory_bot', github: 'thoughtbot/factory_bot', ref: 'f1f77'
+
 gemspec

--- a/app/models/spree/sale_price.rb
+++ b/app/models/spree/sale_price.rb
@@ -3,6 +3,8 @@ module Spree
     acts_as_paranoid
 
     belongs_to :price, class_name: "Spree::Price", touch: true
+    belongs_to :price_with_deleted, -> { with_deleted }, class_name: "Spree::Price", foreign_key: :price_id
+
     delegate :currency, :currency=, to: :price, allow_nil: true
 
     has_one :variant, through: :price

--- a/app/models/spree/sale_price.rb
+++ b/app/models/spree/sale_price.rb
@@ -7,7 +7,7 @@ module Spree
 
     delegate :currency, :currency=, to: :price, allow_nil: true
 
-    has_one :variant, through: :price
+    has_one :variant, through: :price_with_deleted
     has_one :product, through: :variant
 
     has_one :calculator, class_name: "Spree::Calculator", as: :calculable, dependent: :destroy

--- a/spec/models/sale_price_spec.rb
+++ b/spec/models/sale_price_spec.rb
@@ -50,6 +50,20 @@ describe Spree::SalePrice do
     end
   end
 
+  describe '#variant association' do
+    context 'when the price has been soft-deleted' do
+      before do
+        sale = create :sale_price
+        sale.price.destroy
+      end
+
+      it 'preloads the variant via SQL also for soft-deleted records' do
+        records = Spree::SalePrice.with_deleted.includes(:variant)
+        expect(records.first.variant).to be_present
+      end
+    end
+  end
+
   context 'touching associated product when destroyed' do
     subject { -> { sale_price.reload.destroy } }
     let!(:product) { sale_price.product }

--- a/spec/models/sale_price_spec.rb
+++ b/spec/models/sale_price_spec.rb
@@ -35,6 +35,21 @@ describe Spree::SalePrice do
     expect(money.money.currency).to eq(sale_price.currency)
   end
 
+  context 'when the associated price is destroyed' do
+    subject { create(:sale_price) }
+    let(:price) { subject.price }
+
+    before do
+      price.destroy
+      subject.reload
+    end
+
+    it 'still can find the price via price_with_deleted association' do
+      expect(subject.price).to be_nil
+      expect(subject.price_with_deleted).to eql price
+    end
+  end
+
   context 'touching associated product when destroyed' do
     subject { -> { sale_price.reload.destroy } }
     let!(:product) { sale_price.product }


### PR DESCRIPTION
For `SalePrice` records with soft-deleted price, when preloading variants via
SQL with `Spree::SalePrice.includes(:variant)` the variant is `nil` unless we
go through a `price` association that includes also soft-deleted price records.

So the new `price_with_deleted` relation has been added to `Spree::SalePrice` 
model.