### PR TITLE
Add location_after_destroy to admin controller

### DIFF
--- a/app/controllers/spree/admin/sale_prices_controller.rb
+++ b/app/controllers/spree/admin/sale_prices_controller.rb
@@ -34,6 +34,10 @@ module Spree
 
       private
 
+      def location_after_destroy
+        admin_product_sale_prices_path(@product)
+      end
+      
       def location_after_save
         admin_product_sale_prices_path(@product)
       end


### PR DESCRIPTION
After destroy `Solidus::Admin::ResourceController` uses the `location_after_destroy` method to redirect an admin user.

Currently 404s as it uses the default `collection_url` and not the `admin_product_sale_prices_path`

This PR fixes that