### PR TITLE
Support flatpickr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,16 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.1 DB=mysql
-    - SOLIDUS_BRANCH=v2.1 DB=postgres
-    - SOLIDUS_BRANCH=v2.2 DB=mysql
-    - SOLIDUS_BRANCH=v2.2 DB=postgres
-    - SOLIDUS_BRANCH=v2.3 DB=mysql
-    - SOLIDUS_BRANCH=v2.3 DB=postgres
-    - SOLIDUS_BRANCH=v2.4 DB=mysql
-    - SOLIDUS_BRANCH=v2.4 DB=postgres
+    - SOLIDUS_BRANCH=v2.5 DB=mysql
+    - SOLIDUS_BRANCH=v2.5 DB=postgres
+    - SOLIDUS_BRANCH=v2.6 DB=mysql
+    - SOLIDUS_BRANCH=v2.6 DB=postgres
+    - SOLIDUS_BRANCH=v2.7 DB=mysql
+    - SOLIDUS_BRANCH=v2.7 DB=postgres
+    - SOLIDUS_BRANCH=v2.8 DB=mysql
+    - SOLIDUS_BRANCH=v2.8 DB=postgres
+    - SOLIDUS_BRANCH=v2.9 DB=mysql
+    - SOLIDUS_BRANCH=v2.9 DB=postgres
 before_install:
   - export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
-sudo: false
+sudo: required
+cache: bundler
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.4.3
+addons:
+  chrome: stable
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sleep 3 # give xvfb some time to start
 env:
   matrix:
     - SOLIDUS_BRANCH=v2.5 DB=mysql
@@ -14,9 +21,3 @@ env:
     - SOLIDUS_BRANCH=v2.8 DB=postgres
     - SOLIDUS_BRANCH=v2.9 DB=mysql
     - SOLIDUS_BRANCH=v2.9 DB=postgres
-before_install:
-  - export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
-  - if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi
-  - if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi
-  - if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi
-  - phantomjs --version

--- a/README.md
+++ b/README.md
@@ -24,13 +24,9 @@ Install the Gem:
 
     bundle install
 
-Copy the migrations in your app:
+Copy assets files and run migrations
 
-    bundle exec rake railties:install:migrations
-
-Run database migrations in your app:
-
-    bundle exec rake db:migrate
+bundle exec rails generate solidus_sale_prices:install
 
 Usage
 -----

--- a/app/assets/javascripts/spree/backend/flatpickr.js
+++ b/app/assets/javascripts/spree/backend/flatpickr.js
@@ -1,0 +1,26 @@
+SpreeSalePrices = {
+  init: function() {
+    flatpickr.localize({
+      weekdays: {
+        shorthand: Spree.t('abbr_day_names')
+      },
+      months: {
+        longhand: Spree.t('month_names')
+      }
+    });
+
+    datetimepickers = document.querySelectorAll(".datetimepicker");
+
+    for(var datetimepicker of datetimepickers){
+      fp = flatpickr(datetimepicker, {
+        enableTime: true,
+        allowInput: true,
+        dateFormat: 'Y/m/d G:i K'
+      });
+    }
+  }
+}
+
+$(document).ready(function() {
+  SpreeSalePrices.init();
+});

--- a/app/assets/javascripts/spree/backend/solidus_sale_prices.js
+++ b/app/assets/javascripts/spree/backend/solidus_sale_prices.js
@@ -1,31 +1,3 @@
-//= require jquery-ui-timepicker-addon
-
-SpreeSalePrices = {
-  handleDatetimePickerFields: function() {
-    $('.datetimepicker').datetimepicker({
-      dateFormat: Spree.translations.date_picker.js_format,
-      timeFormat: "hh:mm tt",
-      dayNames: Spree.translations.abbr_day_names,
-      dayNamesMin: Spree.translations.abbr_day_names,
-      firstDay: Spree.translations.first_day,
-      monthNames: Spree.translations.month_names,
-      prevText: Spree.translations.previous,
-      nextText: Spree.translations.next,
-      showOn: "focus",
-      oneLine: true
-    });
-  },
-
-  handleSelect2Fields: function() {
-    $('.variant_sales_picker').select2();
-  },
-
-  init: function() {
-    SpreeSalePrices.handleDatetimePickerFields();
-    SpreeSalePrices.handleSelect2Fields();
-  }
-}
-
 $(document).ready(function() {
-  SpreeSalePrices.init();
+  $('.variant_sales_picker').select2();
 });

--- a/app/helpers/spree/base_helper_decorator.rb
+++ b/app/helpers/spree/base_helper_decorator.rb
@@ -2,15 +2,13 @@ Spree::BaseHelper.class_eval do
   def display_original_price(product_or_variant)
     product_or_variant.original_price_in(_current_currency).display_price.to_html
   end
-  
+
   def display_discount_percent(product_or_variant, append_text = 'Off')
     discount = product_or_variant.discount_percent_in _current_currency
-    
-    if discount > 0
-      return "#{number_to_percentage(discount, precision: 0).to_html} #{append_text}"
-    else
-      return ''
-    end 
+
+    return "#{number_to_percentage(discount, precision: 0).to_html} #{append_text}" if discount > 0
+
+    ''
   end
 
   # Check if a sale is the current sale for a product, returns true or false
@@ -22,9 +20,10 @@ Spree::BaseHelper.class_eval do
     try(:supported_currencies) || [ _current_currency ]
   end
 
-  private
-    def _current_currency
-      try(:current_currency) || Spree::Config[:currency] || 'USD'
-    end
 
+  private
+
+  def _current_currency
+    try(:current_currency) || Spree::Config[:currency] || 'USD'
+  end
 end

--- a/app/helpers/spree/base_helper_decorator.rb
+++ b/app/helpers/spree/base_helper_decorator.rb
@@ -20,7 +20,6 @@ Spree::BaseHelper.class_eval do
     try(:supported_currencies) || [ _current_currency ]
   end
 
-
   private
 
   def _current_currency

--- a/app/overrides/admin_product_tabs.rb
+++ b/app/overrides/admin_product_tabs.rb
@@ -1,5 +1,0 @@
-Deface::Override.new(virtual_path: "spree/admin/shared/_product_tabs",
-                     name: "add_sale_prices_tab",
-                     insert_bottom: "[data-hook='admin_product_tabs']",
-                     text: "<%= content_tag :li, :class => ('active' if current == 'Product Sale Prices') do %><%= link_to Spree.t(:product_sale_prices), admin_product_sale_prices_path(@product) %><% end %>",
-                     disabled: false)

--- a/app/overrides/spree/admin/shared/_product_tabs/add_sale_prices_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_sale_prices_tab.html.erb.deface
@@ -1,0 +1,5 @@
+<!-- insert_bottom "[data-hook='admin_product_tabs']" -->
+
+<%= content_tag :li, :class => ('active' if current == 'Product Sale Prices') do %>
+  <%= link_to Spree.t(:product_sale_prices), admin_product_sale_prices_path(@product) %>
+<% end %>

--- a/app/views/spree/admin/sale_prices/_form.html.erb
+++ b/app/views/spree/admin/sale_prices/_form.html.erb
@@ -7,26 +7,25 @@
     <% end %>
   </legend>
 
-  <% solidus_2_4 = Spree.solidus_gem_version >= Gem::Version.new('2.4.0') %>
-     <%= form_for [:admin, product, sale_price], remote: true do |f| %>
-    <div class="row <%= solidus_2_4 ? 'mb-3' : '' %>">
-      <div class="<%= solidus_2_4 ? 'col-2' : 'columns four' %>">
+  <%= form_for [:admin, product, sale_price], remote: true do |f| %>
+    <div class="row mb-3">
+      <div class="col-2">
         <%= f.label :original_price, Spree.t('original_price') %><br />
         <%= f.text_field :original_price, value: product.original_price, disabled: true %>
       </div>
-      <div class="<%= solidus_2_4 ? 'col-2' : 'columns four' %>">
+      <div class="col-2">
         <%= f.label :value, Spree.t('sale_price_amount') %><br />
         <%= f.text_field :value, required: true, type: :number, step: '0.01' %>
       </div>
-      <div class="<%= solidus_2_4 ? 'col-2' : 'columns four' %>">
+      <div class="col-2">
         <%= f.label :currency, Spree.t('sale_price_currency') %><br />
         <%= f.select :currency, options_for_select(supported_currencies_for_sale_price) %>
       </div>
     </div>
 
     <% if product.has_variants? %>
-      <div class="row <%= solidus_2_4 ? 'mb-3' : '' %>">
-        <div class="<%= solidus_2_4 ? 'col-10' : 'columns ten' %>">
+      <div class="row mb-3">
+        <div class="col-10">
           <%= label_tag 'variant_ids[]', Spree.t('variants') %><br />
           <%= select_tag 'variant_ids[]',
                          options_from_collection_for_select(
@@ -36,21 +35,21 @@
       </div>
     <% end %>
 
-    <div class="row <%= solidus_2_4 ? 'mb-3' : '' %>">
-      <div class="<%= solidus_2_4 ? 'col-2' : 'columns four' %>">
+    <div class="row mb-3">
+      <div class="col-2">
         <%= f.label :start_at, Spree.t('sale_price_start_at') %><br />
         <%= f.text_field :start_at, class: "datetimepicker",
                                     value: sale_price.start_at.present? ? l(sale_price.start_at, format: :datetimepicker) : "" %>
       </div>
-      <div class="<%= solidus_2_4 ? 'col-2' : 'columns four' %>">
+      <div class="col-2">
         <%= f.label :end_at, Spree.t('sale_price_end_at') %><br />
         <%= f.text_field :end_at, class: "datetimepicker",
                                   value: sale_price.end_at.present? ? l(sale_price.end_at, format: :datetimepicker) : "" %>
       </div>
     </div>
 
-    <div class="row <%= solidus_2_4 ? 'mb-3' : '' %>">
-      <div class="<%= solidus_2_4 ? 'col-3' : 'columns three' %>">
+    <div class="row mb-3">
+      <div class="col-3">
         <% if sale_price.new_record? %>
           <%= f.submit Spree.t('add_sale_button') %>
         <% else %>

--- a/lib/generators/solidus_sale_prices/install/install_generator.rb
+++ b/lib/generators/solidus_sale_prices/install/install_generator.rb
@@ -2,8 +2,9 @@ module SolidusSalePrices
   module Generators
     class InstallGenerator < Rails::Generators::Base
       def add_javascripts
-        append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_sale_prices\n"
+        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/flatpickr\n"
         append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/solidus_sale_prices\n"
+        append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_sale_prices\n"
       end
 
       def add_stylesheets

--- a/lib/solidus_sale_prices.rb
+++ b/lib/solidus_sale_prices.rb
@@ -3,3 +3,4 @@ require 'spree_core'
 require 'solidus_support'
 
 require 'solidus_sale_prices/engine'
+require 'deface'

--- a/solidus_sale_prices.gemspec
+++ b/solidus_sale_prices.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
 
   solidus_version = [">= 1.0", "< 3"]
 
+  s.add_runtime_dependency 'deface', '~> 1.0'
+
   s.add_dependency "solidus_api", solidus_version
   s.add_dependency "solidus_backend", solidus_version
   s.add_dependency "solidus_core", solidus_version

--- a/solidus_sale_prices.gemspec
+++ b/solidus_sale_prices.gemspec
@@ -25,16 +25,18 @@ Gem::Specification.new do |s|
   s.add_dependency "solidus_api", solidus_version
   s.add_dependency "solidus_backend", solidus_version
   s.add_dependency "solidus_core", solidus_version
-  s.add_dependency 'solidus_support', '~> 0.2'
+  s.add_dependency "solidus_support", '>= 0.3.1'
 
-  s.add_development_dependency 'rspec-rails', '~> 3.1'
   s.add_development_dependency 'capybara', '~> 2.4'
+  s.add_development_dependency 'capybara-screenshot'
   s.add_development_dependency 'database_cleaner', '~> 1.4'
   s.add_development_dependency 'factory_bot', '~> 4.5'
+  s.add_development_dependency 'ffaker'
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'rspec-rails', '~> 3.1'
+  s.add_development_dependency 'selenium-webdriver', '~> 3.142'
   s.add_development_dependency 'simplecov', '~> 0.9'
   s.add_development_dependency 'sqlite3', '~> 1.3'
   s.add_development_dependency 'timecop', '~> 0.9'
-  s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'poltergeist'
-  s.add_development_dependency 'pry'
+  s.add_development_dependency 'webdrivers'
 end

--- a/spec/features/admin/sale_prices_spec.rb
+++ b/spec/features/admin/sale_prices_spec.rb
@@ -97,12 +97,21 @@ RSpec.feature 'Admin sale prices' do
       scenario 'only certain variants are added if selected' do
         visit spree.admin_product_sale_prices_path(product_id: product.slug)
 
+        find('#sale_price_start_at').click
+        find(".flatpickr-day[aria-label='#{2.day.ago.strftime('%B %e, %Y')}']").click
+
+        find('#sale_price_end_at').click
+        find(".flatpickr-day[aria-label='#{2.day.from_now.strftime('%B %e, %Y')}']").click
+
         fill_in('Sale Price', with: 32.33)
-        fill_in('Sale Start Date', with: '2016/12/11 16:12')
-        fill_in('Sale End Date', with: '2016/12/17 05:35 pm')
-        select(product.master.sku_and_options_text, from: 'Variants', visible: false)
-        select(small.sku_and_options_text, from: 'Variants', visible: false)
-        select(medium.sku_and_options_text, from: 'Variants', visible: false)
+
+        find('.select2-choices').click
+        find('.select2-result-label', exact_text: product.master.sku_and_options_text).click
+        find('.select2-choices').click
+        find('.select2-result-label', exact_text: small.sku_and_options_text).click
+        find('.select2-choices').click
+        find('.select2-result-label', exact_text: medium.sku_and_options_text).click
+
         click_button('Add Sale Price')
         expect(page).to have_selector('[data-hook="products_row"]', count: 3)
       end
@@ -110,11 +119,19 @@ RSpec.feature 'Admin sale prices' do
       scenario 'only non-master variants are added if selected' do
         visit spree.admin_product_sale_prices_path(product_id: product.slug)
 
+        find('#sale_price_start_at').click
+        find(".flatpickr-day[aria-label='#{2.day.ago.strftime('%B %e, %Y')}']").click
+
+        find('#sale_price_end_at').click
+        find(".flatpickr-day[aria-label='#{2.day.from_now.strftime('%B %e, %Y')}']").click
+
         fill_in('Sale Price', with: 32.33)
-        fill_in('Sale Start Date', with: '2016/12/11 16:12')
-        fill_in('Sale End Date', with: '2016/12/17 05:35 pm')
-        select(small.sku_and_options_text, from: 'Variants', visible: false)
-        select(medium.sku_and_options_text, from: 'Variants', visible: false)
+
+        find('.select2-choices').click
+        find('.select2-result-label', exact_text: small.sku_and_options_text).click
+        find('.select2-choices').click
+        find('.select2-result-label', exact_text: medium.sku_and_options_text).click
+
         click_button('Add Sale Price')
         expect(page).to have_selector('[data-hook="products_row"]', count: 2)
       end
@@ -129,6 +146,10 @@ RSpec.feature 'Admin sale prices' do
       medium
     end
 
+    def match_date(date)
+      Regexp.new(Regexp.escape(I18n.l(date, format: :datetimepicker)), 'i')
+    end
+
     scenario 'updates the sale price inplace' do
       visit spree.admin_product_sale_prices_path(product_id: product.slug)
 
@@ -136,12 +157,18 @@ RSpec.feature 'Admin sale prices' do
       expect(page).to have_selector('[data-hook="products_row"]', count: 1)
 
       expect(find_field('Sale Price', with: '54.95')).to be_visible
-      expect(find_field('Sale Start Date', with: I18n.l(1.day.ago, format: :datetimepicker))).to be_visible
-      expect(find_field('Sale End Date', with: I18n.l(1.day.from_now, format: :datetimepicker))).to be_visible
+
+      expect(find_field('Sale Start Date', with: match_date(1.day.ago))).to be_visible
+      expect(find_field('Sale End Date', with: match_date(1.day.from_now))).to be_visible
+
+      find('#sale_price_end_at').click
+      find(".flatpickr-day[aria-label='#{2.day.from_now.strftime('%B %e, %Y')}']").click
+
+      find('#sale_price_start_at').click
+      find(".flatpickr-day[aria-label='#{2.day.ago.strftime('%B %e, %Y')}']").click
 
       fill_in('Sale Price', with: 32.33)
-      fill_in('Sale Start Date', with: I18n.l(2.days.ago, format: :datetimepicker))
-      fill_in('Sale End Date', with: I18n.l(2.days.from_now, format: :datetimepicker))
+
       click_button('Update Sale Price')
 
       expect(page).to have_selector('[data-hook="products_row"]', count: 1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,6 @@ require 'rspec/rails'
 require 'database_cleaner'
 require 'ffaker'
 require 'timecop'
-require 'capybara/poltergeist'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -33,6 +32,8 @@ require 'spree/testing_support/capybara_ext'
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/factories'
 require 'spree/testing_support/url_helpers'
+require 'solidus_support/extension/feature_helper'
+require 'webdrivers'
 
 # Requires factories defined in lib/spree_sale_prices/factories.rb
 require 'solidus_sale_prices/factories'
@@ -89,10 +90,4 @@ RSpec.configure do |config|
 
   config.fail_fast = ENV['FAIL_FAST'] || false
   config.order = "random"
-
-  Capybara.javascript_driver = :poltergeist
-  Capybara.default_max_wait_time = 5
-  Capybara.register_driver :poltergeist do |app|
-    Capybara::Poltergeist::Driver.new(app, timeout: 1.minute, phantomjs_options: ['--load-images=no'])
-  end
 end


### PR DESCRIPTION
In solidus 2.5 the jquery-ui-datepicker has been replaced with Flatpickr.
This extension requires a way to set also the time on start and end date of sale price.

This PR is going to add the ability to support DateTime using Flatpickr.