### PR TITLE
Make Factorybot use dynamic attributes

### DIFF
--- a/lib/solidus_sale_prices/factories.rb
+++ b/lib/solidus_sale_prices/factories.rb
@@ -5,16 +5,16 @@ FactoryBot.define do
   # require 'spree_sale_prices/factories'
 
   factory :sale_price, class: Spree::SalePrice do
-    value 10.90
-    start_at nil
-    end_at nil
-    enabled false
+    value { 10.90 }
+    start_at { nil }
+    end_at { nil }
+    enabled { false }
     calculator { Spree::Calculator::FixedAmountSalePriceCalculator.new }
     association :price, factory: :international_price
 
     factory :active_sale_price do
       start_at { Time.now }
-      enabled true
+      enabled { true }
     end
   end
 


### PR DESCRIPTION
Considering this is the current output when running the specs:

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block
```

The factories' attributes have been changed to always use a block so
that the deprecation warning doesn't spam everyone using these
factories.