### PR TITLE
Update dependecy matrix with supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,16 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.1 DB=mysql
-    - SOLIDUS_BRANCH=v2.1 DB=postgres
-    - SOLIDUS_BRANCH=v2.2 DB=mysql
-    - SOLIDUS_BRANCH=v2.2 DB=postgres
-    - SOLIDUS_BRANCH=v2.3 DB=mysql
-    - SOLIDUS_BRANCH=v2.3 DB=postgres
-    - SOLIDUS_BRANCH=v2.4 DB=mysql
-    - SOLIDUS_BRANCH=v2.4 DB=postgres
+    - SOLIDUS_BRANCH=v2.5 DB=mysql
+    - SOLIDUS_BRANCH=v2.5 DB=postgres
+    - SOLIDUS_BRANCH=v2.6 DB=mysql
+    - SOLIDUS_BRANCH=v2.6 DB=postgres
+    - SOLIDUS_BRANCH=v2.7 DB=mysql
+    - SOLIDUS_BRANCH=v2.7 DB=postgres
+    - SOLIDUS_BRANCH=v2.8 DB=mysql
+    - SOLIDUS_BRANCH=v2.8 DB=postgres
+    - SOLIDUS_BRANCH=v2.9 DB=mysql
+    - SOLIDUS_BRANCH=v2.9 DB=postgres
 before_install:
   - export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi


### PR DESCRIPTION
This extension ran on some pretty EOLed Solidus versions.

With this change we'll be running the proper ones: 2.5, 2.6, 2.7, 2.8,
2.9